### PR TITLE
Add Docker to dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 version: 2
 updates:
-  # GitHub Actions
-  - package-ecosystem: 'github-actions'
-    rebase-strategy: disabled
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
Allows dependabot to raise PRs for updates to the base image