### PR TITLE
Update gotenberg to 8.32.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gotenberg/gotenberg:8.24.0
+FROM gotenberg/gotenberg:8.32.0
 
 USER root
 


### PR DESCRIPTION
Same as the dependabot PR #14 , but I need this branch to be built and pushed as a Docker image into AWS ECR with the version tag so I can try it locally on my minikube. According to the project readme creating this branch will cause a new image to be built and pushed up.